### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/backend-publish.yml
+++ b/.github/workflows/backend-publish.yml
@@ -21,7 +21,7 @@ jobs:
           path: go/src/github.com/typeblind/typeblind/
 
       - name: Publish Server to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.TYPECODE_API }}
           username: ${{secrets.DOCKER_LOGIN}}

--- a/.github/workflows/db-service-publish.yml
+++ b/.github/workflows/db-service-publish.yml
@@ -21,7 +21,7 @@ jobs:
         path: go/src/github.com/typeblind/typeblind/
 
     - name: Publish Server to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ secrets.TYPECODE_DB_IMAGE }}
         username: ${{secrets.DOCKER_LOGIN}}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore